### PR TITLE
Amend Typo in Hidden Options

### DIFF
--- a/docs/shopgui/hidden-options.md
+++ b/docs/shopgui/hidden-options.md
@@ -5,7 +5,7 @@ There are some hidden configuration options that can resolve some potential issu
 ## Click Cooldown
 Using the `clickCooldown` option can change the time allowed between clicks in the GUI in milliseconds.
 
- <p class="error"><b>WARNING:</b> This setting is dangerous. This is used to prevent duplication bugs, and is set to 250ms to prevent this. Removing this cooldown can harm changes of duplication. </p>
+ <p class="error"><b>WARNING:</b> This setting is dangerous. This is used to prevent duplication bugs, and is set to 250ms to prevent this. Removing this cooldown can harm chances of duplication. </p>
 
  This can be changed by inserting the following setting in the [`config.yml`](https://pastebin.com/KiM3PjU7):
  ```yaml


### PR DESCRIPTION
A typo has been found within [the click cooldown section of hidden options.](https://docs.brcdev.net/#/shopgui/hidden-options?id=click-cooldown) This PR aims to amend such a typo.